### PR TITLE
파일 오픈 후, 같은 .blend 파일을 import 했을 때 노출되는 에러 알림 번역

### DIFF
--- a/po/ko.po
+++ b/po/ko.po
@@ -92478,3 +92478,10 @@ msgstr "OK 버튼 클릭 시, 팝업을 닫고, 현재 버전으로 에이블러
 
 msgid "File Select Error. No selected file."
 msgstr "파일 선택 오류. 선택된 파일이 없습니다."
+
+
+msgid "Import Failure"
+msgstr "가져오기 실패"
+
+msgid "Cannot import exact same file from same directory."
+msgstr "같은 경로의 동일한 파일을 불러올 수 없습니다."


### PR DESCRIPTION
## 관련 링크

- [파일 오픈 후, .blend 파일 import 에러 처리 #138](https://github.com/ACON3D/blender/pull/138)


## 발제/내용

- 위 작업에서 필요한 내용의 번역을 추가하였습니다.


## 대응

### 어떤 조치를 취했나요?

- `ko.po` 파일에 관련 내용 추가