### PR TITLE
과거버전에서의 문구가 잘못표시되어있어서 수정함

### DIFF
--- a/po/ko.po
+++ b/po/ko.po
@@ -92511,7 +92511,7 @@ msgid "This file was created in a older version of ABLER ($(fileVer))"
 msgstr "이 파일은 현재 설치된 에이블러 버전보다 하위 버전에서 작성되었습니다. (버전 : $(fileVer))"
 
 
-msgid "If you save in the current version ($(clientVer)), you w ill not be able to load this file from older version of ABLER."
+msgid "If you save in the current version ($(clientVer)), you will not be able to load this file from older version of ABLER."
 msgstr "현재 버전($(clientVer))에서 파일을 저장할 경우, 이전 버전의 ABLER 에서 이 파일을 로드할 수 없습니다."
 
 


### PR DESCRIPTION
## 관련 링크

[이슈 링크](https://www.notion.so/acon3d/Issue-0051_-af0482022f7f4044855203a88ca2334d)


## 발제/내용

- 번역에 오타가 있어서 적용이 제대로 되지 않고 있었음

## 대응

### 어떤 조치를 취했나요?

- 번역에 오타가 있어서 수정했습니다.
