### PR TITLE
렌더 팝업 추가에 따른 번역

### DIFF
--- a/po/ko.po
+++ b/po/ko.po
@@ -92533,3 +92533,23 @@ msgstr "화면을 이동합니다."
 
 msgid "Drag to rotate the view"
 msgstr "화면을 회전합니다."
+
+
+msgid "Render selected scenes?"
+msgstr "선택된 씬을 렌더하시겠습니까?"
+
+
+msgid "High quality render may take a long time to be finished."
+msgstr "고급 렌더는 씬에 포함된 내용에 따라 렌더 시간이 오래 소요될 수 있습니다."
+
+
+msgid "Render can be canceled after starting."
+msgstr "렌더는 시작 후 취소가 가능합니다."
+
+
+msgid "Selected Scenes : "
+msgstr "선택된 씬 : "
+
+
+msgid "Save and Render"
+msgstr "저장 후 렌더"


### PR DESCRIPTION
## 관련 링크

[사양서 링크](https://docs.google.com/document/d/1c7Spx-o5G4xkaWfi_rF7Fv08aRDpCrs4gYjn1dKvfVg/edit)


## 발제/내용

- 렌더링 확인을 위한 팝업을 노출이 필요

## 대응

### 어떤 조치를 취했나요?

- https://github.com/ACON3D/blender/pull/192/commits/9af0e4805ea6729536707c1ca81117117e68009a
- 위와 같이 작업한 뒤, 해당 작업내용에 맞는 번역 내용을 추가했음