### PR TITLE
한국어 버전에서 Automatic 번역 수정

### DIFF
--- a/po/ko.po
+++ b/po/ko.po
@@ -65802,7 +65802,7 @@ msgstr "번역에 사용된 언어"
 
 
 msgid "Automatic (Automatic)"
-msgstr "자동 (Automatic)"
+msgstr "자동 (자동)"
 
 
 msgid "Automatically choose system's defined language if available, or fall-back to English"


### PR DESCRIPTION
## 관련 링크

[한국어 버전에서 Automatic 번역 수정](https://www.notion.so/acon3d/Automatic-779f745f47c340d7809c1d852fbf7f01)


## 발제/내용

- 한국어 버전으로 설정 후 언어 목록에서 `Automatic (Automatic)` 에 대한 번역이 되지 않음.


## 대응

### 어떤 조치를 취했나요?

- 번역 파일에서 `Automatic (Automatic)` 에 대한 번역 처리가 되어 있지 않아서 적용함

```python
# po/ko.po
msgid "Automatic (Automatic)"
msgstr "자동 (자동)"
```
