### PR TITLE
로그인 연속 실패 팝업의 영문 문구가 잘림

### DIFF
--- a/po/ko.po
+++ b/po/ko.po
@@ -92216,7 +92216,7 @@ msgid "Incorrect username or password."
 msgstr "사용자 이름 혹은 패스워드가 올바르지 않습니다."
 
 
-msgid "The number of consecutive password error count exceeded."
+msgid "Login error count exceeded."
 msgstr "비밀번호 오류 횟수 초과로 인해 로그인이 불가합니다."
 
 


### PR DESCRIPTION
## 관련 링크

[태스크](https://www.notion.so/acon3d/69d7e4f44a1742a4a4918b3a534c00dd)
[이슈](https://www.notion.so/acon3d/Issue-0116-79ed8183a58a4d999852f2235b11af30)
[ABLER PR](https://github.com/ACON3D/blender/pull/271)


## 발제/내용

- 로그인 연속 실패 팝업의 영문 문구가 잘려서 보인다.

## 대응

### 어떤 조치를 취했나요?

- 로그인 연속 실패 팝업의 영문 문구를 짧게 변경하였습니다.